### PR TITLE
Rework how the state works after real-world github usage

### DIFF
--- a/.github/workflows/pully.yml
+++ b/.github/workflows/pully.yml
@@ -5,14 +5,17 @@ on:
     types: [submitted]
 
 concurrency:
-  group: pully # We can only run one instance at a time due to how the pully state works
-  cancel-in-progress: false
+  group: pully-${{github.event.pull_request.number}}
+  # Github concurrency lacks some important functionality (max 1 pending job in the group is allowed)
+  # So we just have to cancel old jobs and let the latest job for a PR do the heavy lifting
+  cancel-in-progress: true 
 
 jobs:
   pully:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js version specified in .nvmrc

--- a/.github/workflows/pully/app.ts
+++ b/.github/workflows/pully/app.ts
@@ -1,18 +1,18 @@
-import fs, { readFileSync } from "fs";
-import {
-	PullRequestClosedEvent,
-	PullRequestConvertedToDraftEvent,
-	PullRequestEditedEvent,
-	PullRequestEvent,
-	PullRequestOpenedEvent,
-	PullRequestReadyForReviewEvent,
-	PullRequestReopenedEvent,
-	PullRequestReviewRequestedEvent,
-	PullRequestReviewSubmittedEvent,
-} from "@octokit/webhooks-types";
-import { WebClient } from "@slack/web-api";
-import assert from "assert";
-import { Octokit } from "octokit";
+import { readFileSync } from 'fs';
+import type {
+  PullRequestClosedEvent,
+  PullRequestConvertedToDraftEvent,
+  PullRequestEditedEvent,
+  PullRequestEvent,
+  PullRequestOpenedEvent,
+  PullRequestReadyForReviewEvent,
+  PullRequestReopenedEvent,
+  PullRequestReviewRequestedEvent,
+  PullRequestReviewSubmittedEvent,
+} from '@octokit/webhooks-types';
+import { WebClient } from '@slack/web-api';
+import assert from 'assert';
+import { Octokit } from 'octokit';
 
 // Environment variables
 // TODO: Make sure not to require github if we are actually making this vendor-agnostic at some point..
@@ -22,471 +22,395 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_EVENT_PATH = process.env.GITHUB_EVENT_PATH;
 
 assert(
-	!!GITHUB_REPOSITORY_OWNER,
-	"GITHUB_REPOSITORY_OWNER, i.e. the owner of the repo this is running for, was unexpectedly undefined in the runtime environment!",
+  !!GITHUB_REPOSITORY_OWNER,
+  'GITHUB_REPOSITORY_OWNER, i.e. the owner of the repo this is running for, was unexpectedly undefined in the runtime environment!',
 );
 assert(
-	!!GITHUB_REPOSITORY,
-	"GITHUB_REPOSITORY, i.e. <owner/reponame> from github, was unexpectedly undefined in the runtime environment.",
+  !!GITHUB_REPOSITORY,
+  'GITHUB_REPOSITORY, i.e. <owner/reponame> from github, was unexpectedly undefined in the runtime environment.',
 );
 assert(
-	!!GITHUB_TOKEN,
-	"GITHUB_TOKEN was undefined in the environment! This must be set to a token with read and write access to the repo's pully-persistent-state-do-not-use-for-coding branch",
+  !!GITHUB_TOKEN,
+  "GITHUB_TOKEN was undefined in the environment! This must be set to a token with read and write access to the repo's pully-persistent-state-do-not-use-for-coding branch",
 );
-assert(!!GITHUB_EVENT_PATH, "GITHUB_EVENT_PATH was undefined in the environment! This should be provided by Github CI and is the same payload as the pull_request and pull_request_review webhooks: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request");
+assert(
+  !!GITHUB_EVENT_PATH,
+  'GITHUB_EVENT_PATH was undefined in the environment! This should be provided by Github CI and is the same payload as the pull_request and pull_request_review webhooks: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request',
+);
 
 const PULLY_SLACK_TOKEN = process.env.PULLY_SLACK_TOKEN as string;
 const PULLY_SLACK_CHANNEL = process.env.PULLY_SLACK_CHANNEL as string;
-assert(!!PULLY_SLACK_TOKEN, "PULLY_SLACK_TOKEN was not defined in the environment");
-assert(
-	!!PULLY_SLACK_CHANNEL,
-	"PULLY_SLACK_CHANNEL (the slack channel id) was not defined in the environment",
-);
+assert(!!PULLY_SLACK_TOKEN, 'PULLY_SLACK_TOKEN was not defined in the environment');
+assert(!!PULLY_SLACK_CHANNEL, 'PULLY_SLACK_CHANNEL (the slack channel id) was not defined in the environment');
 
-const GITHUB_REPOSITORY_WITHOUT_OWNER = GITHUB_REPOSITORY.replace(`${GITHUB_REPOSITORY_OWNER}/`, ''); 
+const GITHUB_REPOSITORY_WITHOUT_OWNER = GITHUB_REPOSITORY.replace(`${GITHUB_REPOSITORY_OWNER}/`, '');
 
 // Typedefs
 type PrNumber = number;
 type SlackMessageTimestamp = string;
 type PrState = 'open' | 'closed' | 'merged' | 'queued' | 'draft';
-type ReviewerState =
-	| "approved"
-	| "requested-changes"
-	| "review_requested"
-	| "dismissed";
+type ReviewerState = 'approved' | 'requested-changes' | 'review_requested' | 'dismissed';
 
 type GithubUsername = string;
 type Reviewers = Record<GithubUsername, ReviewerState>;
 type PrData = Record<PrNumber, IPrData>;
 type RepoFullname = string;
-type RepoData = Record<RepoFullname, IRepoData>;
 type PullyData = {
-	repodata: RepoData;
-	known_authors: AuthorInfo[];
+  known_authors: AuthorInfo[];
 };
 
 interface AuthorInfo {
-	githubUsername?: string;
-	slackMemberId?: string;
-	firstName?: string;
+  githubUsername?: string;
+  slackMemberId?: string;
+  firstName?: string;
 }
 
 interface IPrData {
-	reviews: Reviewers;
-	/**
-	 * This repo explicitly assumes one slack message (and thus channel) per pull request
-	 */
-	message?: SlackMessageTimestamp;
+  reviews: Reviewers;
+  /**
+   * This repo explicitly assumes one slack message (and thus channel) per pull request
+   */
+  message?: SlackMessageTimestamp;
 }
 
-interface IRepoData {
-	prData: PrData;
-}
+const postToSlack = async (slackMessageContent: string, prNumber: number) => {
+  // TODO: Determine existing message timestamp by checking state for timestamp file
+  const web = new WebClient(PULLY_SLACK_TOKEN);
+  const octokit = new Octokit({ auth: GITHUB_TOKEN });
 
-const postToSlack = async (
-	slackMessageContent: string,
-	pullyPrDataCache: IPrData,
+  let existingMessageTimestamp: string | undefined;
+  const messagePath = `messages/${GITHUB_REPOSITORY_OWNER}_${GITHUB_REPOSITORY_WITHOUT_OWNER}_${prNumber}.timestamp`;
+  try {
+    const pullyStateRaw = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+      repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+      owner: GITHUB_REPOSITORY_OWNER,
+      path: messagePath,
+      ref: 'refs/heads/pully-persistent-state-do-not-use-for-coding',
+    });
+
+    // @ts-expect-error need to assert that this is file somehow
+    const timestampFile: { timestamp: string } = JSON.parse(atob(pullyStateRaw.data.content));
+    existingMessageTimestamp = timestampFile.timestamp;
+  } catch (e: unknown) {
+    console.log('Error when getting existing timestamp...');
+    console.log(e); // Assuming file not found
+  }
+
+  if (existingMessageTimestamp) {
+    web.chat.update({
+      text: slackMessageContent,
+      channel: PULLY_SLACK_CHANNEL,
+      ts: existingMessageTimestamp,
+    });
+  } else {
+    const value = await web.chat.postMessage({
+      text: slackMessageContent,
+      channel: PULLY_SLACK_CHANNEL,
+    });
+    if (value.ts) {
+      await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+        owner: GITHUB_REPOSITORY_OWNER,
+        repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+        path: messagePath,
+        branch: 'refs/heads/pully-persistent-state-do-not-use-for-coding',
+        message: 'Pully state update',
+        committer: {
+          name: 'Pully',
+          email: 'kris@bitheim.no',
+        },
+        content: btoa(JSON.stringify({timestamp: value.ts})),
+        // sha: sha, We will never update the file since we have one message per pr...
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+    }
+  }
+};
+
+const getAuthorInfoFromGithubLogin = (authorInfos: AuthorInfo[], githubLogin: string): AuthorInfo => {
+  const search = authorInfos.find((value) => value.githubUsername === githubLogin);
+
+  if (search) {
+    return search;
+  }
+
+  return {
+    githubUsername: githubLogin,
+    slackMemberId: undefined,
+    firstName: undefined,
+  };
+};
+
+const constructSlackMessage = async (
+  pullyRepodataCache: PullyData,
+  author: AuthorInfo,
+  prTitle: string,
+  prNumber: PrNumber,
+  prState: PrState,
+  repoFullname: RepoFullname,
+  prUrl: string,
+  lineAdds?: number,
+  lineRemovals?: number,
 ) => {
-	const web = new WebClient(PULLY_SLACK_TOKEN);
+  const authorToUse = author.firstName ?? author.githubUsername;
 
-	if (pullyPrDataCache.message) {
-		web.chat.update({
-			text: slackMessageContent,
-			channel: PULLY_SLACK_CHANNEL,
-			ts: pullyPrDataCache.message,
-		});
-	} else {
-		const value = await web.chat.postMessage({
-			text: slackMessageContent,
-			channel: PULLY_SLACK_CHANNEL,
-		});
-		if (value.ts) {
-			pullyPrDataCache.message = value.ts;
-		}
-	}
-};
+  let statusSlackmoji = '';
+  switch (prState) {
+    case 'closed':
+      statusSlackmoji = ':github-closed:';
+      break;
+    case 'open':
+      statusSlackmoji = ':github-pr:';
+      break;
+    case 'merged':
+      statusSlackmoji = ':github-merged:';
+      break;
+    case 'draft':
+      statusSlackmoji = ':github-pr-draft:';
+      break;
+  }
 
-const getAuthorInfoFromGithubLogin = (
-	authorInfos: AuthorInfo[],
-	githubLogin: string,
-): AuthorInfo => {
-	const search = authorInfos.find(
-		(value) => value.githubUsername === githubLogin,
-	);
+  let linediff = '';
+  if (lineAdds !== undefined && lineRemovals !== undefined) {
+    linediff = `(+${lineAdds}/-${lineRemovals})`;
+  }
 
-	if (search) {
-		return search;
-	}
+  // TODO: need to figure out how to keep '>' in the text without breaking the slack post link
+  let text = `<${prUrl}|[${repoFullname}] ${prTitle.replaceAll('>', '')} (#${prNumber})> ${linediff} by ${authorToUse}`;
 
-	return {
-		githubUsername: githubLogin,
-		slackMemberId: undefined,
-		firstName: undefined,
-	};
-};
+  const octokit = new Octokit({ auth: GITHUB_TOKEN });
+  const prReviews = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
+    owner: GITHUB_REPOSITORY_OWNER,
+    repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+    pull_number: prNumber,
+    headers: {
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
 
+  const reviewRequests = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers', {
+    owner: GITHUB_REPOSITORY_OWNER,
+    repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+    pull_number: prNumber,
+    headers: {
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
 
-const constructSlackMessage = (
-	pullyRepodataCache: PullyData,
-	author: AuthorInfo,
-	prTitle: string,
-	prNumber: PrNumber,
-	prState: PrState,
-	repoFullname: RepoFullname,
-	prUrl: string,
-	lineAdds?: number,
-	lineRemovals?: number,
-) => {
-	let authorToUse = author.firstName ?? author.githubUsername;
+  const reviews: Reviewers = {};
 
-	let statusSlackmoji = "";
-	switch (prState) {
-		case "closed":
-			statusSlackmoji = ":github-closed:";
-			break;
-		case "open":
-			statusSlackmoji = ":github-pr:";
-			break;
-		case "merged":
-			statusSlackmoji = ":github-merged:";
-		case "draft":
-			statusSlackmoji = ":github-pr-draft:";
-	}
+  // Review requests shall be cleared once review is submitted...
+  for (const request of reviewRequests.data.users.reverse()) {
+    // Only use the latest review per user
+    if (!(request.login in prReviews)) {
+      reviews[request.login] = 'review_requested';
+    }
+  }
 
-	let linediff = "";
-	if (lineAdds !== undefined && lineRemovals !== undefined) {
-		linediff = `(+${lineAdds}/-${lineRemovals})`;
-	}
+  // Iterate through the reviews backwards as the latest reviews are reported first...
+  for (const review of prReviews.data.reverse()) {
+    if (review.user?.login !== undefined) {
+      // Only use the latest review per user
+      if (!(review.user.login in prReviews)) {
+        if (review.state === 'APPROVED') {
+          reviews[review.user.login] = 'approved';
+        } else if (review.state === 'CHANGES_REQUESTED') {
+          reviews[review.user.login] = 'requested-changes';
+        }
+      }
+    }
+  }
 
-	// TODO: need to figure out how to keep '>' in the text without breaking the slack post link
-	let text = `<${prUrl}|[${repoFullname}] ${prTitle.replaceAll(">", "")} (#${prNumber})> ${linediff} by ${authorToUse}`;
+  const approvers = new Set();
+  const change_requesters = new Set();
+  const review_requests = new Set();
 
-	if (repoFullname in pullyRepodataCache.repodata) {
-		const specificRepoData = pullyRepodataCache.repodata[repoFullname];
+  for (const [reviewer, state] of Object.entries(reviews)) {
+    const reviewerData = getAuthorInfoFromGithubLogin(pullyRepodataCache.known_authors, reviewer);
+    switch (state) {
+      case 'approved':
+        approvers.add(reviewerData.firstName ?? reviewerData.githubUsername);
+        break;
+      case 'requested-changes':
+        change_requesters.add(reviewerData.firstName ?? reviewerData.githubUsername);
+        break;
+      case 'review_requested':
+        // Only give @ mentions when a review is requested to avoid notification spam
+        review_requests.add(`<@${reviewerData.slackMemberId}>`);
+    }
+  }
 
-		if (prNumber in specificRepoData.prData) {
-			const prReviewData = specificRepoData.prData[prNumber];
+  if (approvers.size !== 0) {
+    text += ' | :github-approve: ' + Array.from(approvers).join(', ');
+  }
 
-			const approvers = new Set();
-			const change_requesters = new Set();
-			const review_requests = new Set();
+  if (prState === 'open') {
+    if (change_requesters.size !== 0) {
+      text += ' | :github-changes-requested: ' + Array.from(change_requesters).join(', ');
+    }
 
-			for (let [reviewer, state] of Object.entries(prReviewData.reviews)) {
-				const reviewerData = getAuthorInfoFromGithubLogin(
-					pullyRepodataCache.known_authors,
-					reviewer,
-				);
-				switch (state) {
-					case "approved":
-						approvers.add(
-							reviewerData.firstName ?? reviewerData.githubUsername,
-						);
-						break;
-					case "requested-changes":
-						change_requesters.add(
-							reviewerData.firstName ?? reviewerData.githubUsername,
-						);
-						break;
-					case "review_requested":
-						// Only give @ mentions when a review is requested to avoid notification spam
-						review_requests.add(`<@${reviewerData.slackMemberId}>`);
-				}
-			}
+    if (review_requests.size !== 0) {
+      text += ' | :code-review: ' + Array.from(review_requests).join(', ');
+    }
+  }
 
-			if (approvers.size !== 0) {
-				text += " | :github-approve: " + Array.from(approvers).join(", ");
-			}
+  if (prState === 'closed' || prState === 'merged') {
+    text = `~${text}~`;
+  }
 
-			if (prState === "open") {
-				if (change_requesters.size !== 0) {
-					text +=
-						" | :github-changes-requested: " +
-						Array.from(change_requesters).join(", ");
-				}
+  text = `${statusSlackmoji} ${text}`;
 
-				if (review_requests.size !== 0) {
-					text += " | :code-review: " + Array.from(review_requests).join(", ");
-				}
-			}
-		}
-	}
-
-	if (prState === "closed" || prState === "merged") {
-		text = `~${text}~`;
-	}
-
-	text = `${statusSlackmoji} ${text}`;
-
-	return text;
-};
-
-const ensureStateIsInitializedForRepoAndPr = (
-	pullyRepodataCache: RepoData,
-	repoFullName: string,
-	prNumber: number,
-) => {
-	if (!(repoFullName in pullyRepodataCache)) {
-		pullyRepodataCache[repoFullName] = {
-			prData: { },
-		};
-	}
-	
-	const repoPrData = pullyRepodataCache[repoFullName].prData;
-
-	if (!(prNumber in repoPrData)){
-		repoPrData[prNumber] = {reviews: {}, message: undefined} 
-	}
-};
-
-const getPrDataCache = (
-	pullyRepodataCache: RepoData,
-	repoFullName: RepoFullname,
-	prNumber: PrNumber,
-): IPrData => {
-	ensureStateIsInitializedForRepoAndPr(
-		pullyRepodataCache,
-		repoFullName,
-		prNumber,
-	);
-	return pullyRepodataCache[repoFullName].prData[prNumber];
+  return text;
 };
 
 const handlePullRequestReviewSubmitted = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestReviewSubmittedEvent,
+  pullyRepodataCache: PullyData,
+  payload: PullRequestReviewSubmittedEvent,
 ) => {
-	console.log("Received a pull request review submitted event");
+  console.log('Received a pull request review submitted event');
 
-	const specificPrData = getPrDataCache(
-		pullyRepodataCache.repodata,
-		payload.repository.full_name,
-		payload.pull_request.number,
-	);
+  const prAuthor = getAuthorInfoFromGithubLogin(
+    pullyRepodataCache.known_authors,
+    payload.pull_request.user?.login ?? 'undefined',
+  );
 
-	const author = getAuthorInfoFromGithubLogin(
-		pullyRepodataCache.known_authors,
-		payload.review.user?.login ?? "undefined",
-	);
+  const prData = payload.pull_request;
+  const slackMessage = await constructSlackMessage(
+    pullyRepodataCache,
+    prAuthor,
+    prData.title,
+    prData.number,
+    prData.state,
+    payload.repository.full_name,
+    prData.html_url,
+    undefined,
+    undefined,
+  );
 
-	// Store only a public identifier in the persistent state
-	if (author.githubUsername) {
-		switch (payload.review.state) {
-			case "approved":
-				console.log("Hai");
-				specificPrData.reviews[author.githubUsername] = "approved";
-				break;
-			case "changes_requested":
-				specificPrData.reviews[author.githubUsername] = "requested-changes";
-				break;
-			case "dismissed":
-				specificPrData.reviews[author.githubUsername] = "dismissed";
-		}
-	}
-
-	const prData = payload.pull_request;
-	const slackMessage = constructSlackMessage(
-		pullyRepodataCache,
-		author,
-		prData.title,
-		prData.number,
-		prData.state,
-		payload.repository.full_name,
-		prData.html_url,
-		undefined,
-		undefined,
-	);
-
-	await postToSlack(slackMessage, specificPrData);
+  await postToSlack(slackMessage, prData.number);
 };
 
 const handlePullRequestReviewRequested = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestReviewRequestedEvent,
+  pullyRepodataCache: PullyData,
+  payload: PullRequestReviewRequestedEvent,
 ) => {
-	const prDataCache = getPrDataCache(
-		pullyRepodataCache.repodata,
-		payload.repository.full_name,
-		payload.pull_request.number,
-	);
-
-	let author: AuthorInfo = { slackMemberId: "", githubUsername: "" };
-	if ("requested_reviewer" in payload) {
-		author = getAuthorInfoFromGithubLogin(
-			pullyRepodataCache.known_authors,
-			payload.requested_reviewer.login,
-		);
-
-		if (author.githubUsername) {
-			prDataCache.reviews[author.githubUsername] = "review_requested";
-		}
-	} else if ("requested_team" in payload) {
-		console.log("TODO we dont handle team review requests just yet.");
-		return;
-	} else {
-		console.log("Unexpected review request format");
-		return;
-	}
-
-	handlePullRequestGeneric(pullyRepodataCache, payload);
+  handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
-const handlePullRequestGeneric = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestEvent,
-) => {
-	const repoFullName = payload.repository.full_name;
-	const prNumber = payload.pull_request.number;
-	const prDataCache = getPrDataCache(
-		pullyRepodataCache.repodata,
-		repoFullName,
-		prNumber,
-	);
-	const prData = payload.pull_request;
+const handlePullRequestGeneric = async (pullyRepodataCache: PullyData, payload: PullRequestEvent) => {
+  const prData = payload.pull_request;
 
-	const author = getAuthorInfoFromGithubLogin(
-		pullyRepodataCache.known_authors,
-		prData.user.login,
-	);
+  const author = getAuthorInfoFromGithubLogin(pullyRepodataCache.known_authors, prData.user.login);
 
-	let prStatus: PrState = prData.state;
+  let prStatus: PrState = prData.state;
 
-	if (prData.draft){
-		prStatus = "draft"
-	}
-	if (prData.merged){
-		prStatus = "merged"
-	}
+  if (prData.draft) {
+    prStatus = 'draft';
+  }
+  if (prData.merged_at != null) {
+    prStatus = 'merged';
+  }
 
-
-	const slackMessage = constructSlackMessage(
-		pullyRepodataCache,
-		author,
-		prData.title,
-		prData.number,
-		prStatus,
-		payload.repository.full_name,
-		prData.html_url,
-		prData.additions,
-		prData.deletions,
-	);
-	await postToSlack(slackMessage, prDataCache);
+  const slackMessage = await constructSlackMessage(
+    pullyRepodataCache,
+    author,
+    prData.title,
+    prData.number,
+    prStatus,
+    payload.repository.full_name,
+    prData.html_url,
+    prData.additions,
+    prData.deletions,
+  );
+  await postToSlack(slackMessage, prData.number);
 };
 
-const handlePullRequestOpened = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestOpenedEvent,
-) => {
-	console.log(
-		`Received a pull request open event for #${payload.pull_request.url}`,
-	);
-	await handlePullRequestGeneric(pullyRepodataCache, payload);
+const handlePullRequestOpened = async (pullyRepodataCache: PullyData, payload: PullRequestOpenedEvent) => {
+  console.log(`Received a pull request open event for #${payload.pull_request.url}`);
+  await handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
-const handlePullRequestReopened = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestReopenedEvent,
-) => {
-	console.log(
-		`Received a pull request open event for #${payload.pull_request.url}`,
-	);
-	await handlePullRequestGeneric(pullyRepodataCache, payload);
+const handlePullRequestReopened = async (pullyRepodataCache: PullyData, payload: PullRequestReopenedEvent) => {
+  console.log(`Received a pull request reopened event for #${payload.pull_request.url}`);
+  await handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
-const handlePullRequestEdited = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestEditedEvent,
-) => {
-	console.log(
-		`Received a pull request open event for #${payload.pull_request.url}`,
-	);
-	await handlePullRequestGeneric(pullyRepodataCache, payload);
+const handlePullRequestEdited = async (pullyRepodataCache: PullyData, payload: PullRequestEditedEvent) => {
+  console.log(`Received a pull request edited event for #${payload.pull_request.url}`);
+  await handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
 const handlePullRequestConvertedToDraft = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestConvertedToDraftEvent,
+  pullyRepodataCache: PullyData,
+  payload: PullRequestConvertedToDraftEvent,
 ) => {
-	console.log(
-		`Received a pull request open event for #${payload.pull_request.url}`,
-	);
-	await handlePullRequestGeneric(pullyRepodataCache, payload);
+  console.log(`Received a pull request converted to draft event for #${payload.pull_request.url}`);
+  await handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
 const handlePullRequestReadyForReview = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestReadyForReviewEvent,
+  pullyRepodataCache: PullyData,
+  payload: PullRequestReadyForReviewEvent,
 ) => {
-	console.log(
-		`Received a pull request open event for #${payload.pull_request.url}`,
-	);
-	await handlePullRequestGeneric(pullyRepodataCache, payload);
+  console.log(`Received a pull request ready for review event for #${payload.pull_request.url}`);
+  await handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
-const handlePullRequestClosed = async (
-	pullyRepodataCache: PullyData,
-	payload: PullRequestClosedEvent,
-) => {
-	console.log(
-		`Received a pull request closed event for ${payload.pull_request.url}`,
-	);
-	await handlePullRequestGeneric(pullyRepodataCache, payload);
+const handlePullRequestClosed = async (pullyRepodataCache: PullyData, payload: PullRequestClosedEvent) => {
+  console.log(`Received a pull request closed event for ${payload.pull_request.url}`);
+  await handlePullRequestGeneric(pullyRepodataCache, payload);
 };
 
 const loadPullyState = async (): Promise<PullyData> => {
-	// TODO: We should create the orphan branch if it doesnt exist already
-	let repoData: PullyData;
-	const octokit = new Octokit({ auth: GITHUB_TOKEN });
-	try {
-		// TODO: Should sanitize json data with a schema
-		const pullyStateRaw = await octokit.request(
-			"GET /repos/{owner}/{repo}/contents/{path}",
-			{
-				repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
-				owner: GITHUB_REPOSITORY_OWNER,
-				path: "pullystate.json",
-				ref: "refs/heads/pully-persistent-state-do-not-use-for-coding",
-			},
-		);
-		// @ts-expect-error need to assert that this is file somehow
-		repoData = JSON.parse(atob(pullyStateRaw.data.content));
-		return repoData;
-	} catch (e) {
-		throw e;
-	}
+  // TODO: We should create the orphan branch if it doesnt exist already
+  let repoData: PullyData;
+  const octokit = new Octokit({ auth: GITHUB_TOKEN });
+  try {
+    // TODO: Should sanitize json data with a schema
+    const pullyStateRaw = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+      repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+      owner: GITHUB_REPOSITORY_OWNER,
+      path: 'pullystate.json',
+      ref: 'refs/heads/pully-persistent-state-do-not-use-for-coding',
+    });
+    // @ts-expect-error need to assert that this is file somehow
+    repoData = JSON.parse(atob(pullyStateRaw.data.content));
+    return repoData;
+  } catch (e) {
+    throw e;
+  }
 };
 
 const savePullyState = async (pullyState: PullyData) => {
-	const octokit = new Octokit({ auth: GITHUB_TOKEN });
-	const pullyStateRaw = await octokit.request(
-		"GET /repos/{owner}/{repo}/contents/{path}",
-		{
-			repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
-			owner: GITHUB_REPOSITORY_OWNER,
-			path: "pullystate.json",
-			ref: "refs/heads/pully-persistent-state-do-not-use-for-coding",
-		},
-	);
+  const octokit = new Octokit({ auth: GITHUB_TOKEN });
+  const pullyStateRaw = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+    repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+    owner: GITHUB_REPOSITORY_OWNER,
+    path: 'pullystate.json',
+    ref: 'refs/heads/pully-persistent-state-do-not-use-for-coding',
+  });
 
-	// @ts-expect-error need to assert that this is file somehow
-	const sha = pullyStateRaw.data.sha;
+  // @ts-expect-error need to assert that this is file somehow
+  const sha = pullyStateRaw.data.sha;
 
-	await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
-		owner: GITHUB_REPOSITORY_OWNER,
-		repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
-		path: "pullystate.json",
-		branch: "refs/heads/pully-persistent-state-do-not-use-for-coding",
-		message: "Pully state update",
-		committer: {
-			name: "Pully",
-			email: "kris@bitheim.no",
-		},
-		content: btoa(JSON.stringify(pullyState)),
-		sha: sha,
-		headers: {
-			"X-GitHub-Api-Version": "2022-11-28",
-		},
-	});
-	console.log("Saved state");
+  await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+    owner: GITHUB_REPOSITORY_OWNER,
+    repo: GITHUB_REPOSITORY_WITHOUT_OWNER,
+    path: 'pullystate.json',
+    branch: 'refs/heads/pully-persistent-state-do-not-use-for-coding',
+    message: 'Pully state update',
+    committer: {
+      name: 'Pully',
+      email: 'kris@bitheim.no',
+    },
+    content: btoa(JSON.stringify(pullyState)),
+    sha: sha,
+    headers: {
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  console.log('Saved state');
 };
 
 // TODO make a main out of this
@@ -494,83 +418,65 @@ const savePullyState = async (pullyState: PullyData) => {
 // LOAD state
 
 loadPullyState().then((repoData) => {
-	const getEventData = ():
-		| PullRequestReviewSubmittedEvent
-		| PullRequestOpenedEvent
-		| PullRequestReviewRequestedEvent
-		| PullRequestClosedEvent
-		| PullRequestReopenedEvent
-		| PullRequestEditedEvent
-		| PullRequestConvertedToDraftEvent
-		| PullRequestReadyForReviewEvent => {
-		let eventData:
-			| PullRequestReviewSubmittedEvent
-			| PullRequestOpenedEvent
-			| PullRequestReviewRequestedEvent
-			| PullRequestClosedEvent | PullRequestReopenedEvent 		| PullRequestEditedEvent
-		| PullRequestConvertedToDraftEvent
-		| PullRequestReadyForReviewEvent;
+  const getEventData = ():
+    | PullRequestReviewSubmittedEvent
+    | PullRequestOpenedEvent
+    | PullRequestReviewRequestedEvent
+    | PullRequestClosedEvent
+    | PullRequestReopenedEvent
+    | PullRequestEditedEvent
+    | PullRequestConvertedToDraftEvent
+    | PullRequestReadyForReviewEvent => {
+    let eventData:
+      | PullRequestReviewSubmittedEvent
+      | PullRequestOpenedEvent
+      | PullRequestReviewRequestedEvent
+      | PullRequestClosedEvent
+      | PullRequestReopenedEvent
+      | PullRequestEditedEvent
+      | PullRequestConvertedToDraftEvent
+      | PullRequestReadyForReviewEvent;
 
-		// TODO: fetch via github state variable
-		try {
-			// TODO: Should sanitize json data
-			eventData = JSON.parse(readFileSync(GITHUB_EVENT_PATH, "utf-8"));
-		} catch {
-			console.warn("No data.json found, starting state from scratch...");
-			throw Error("Could not read the event data");
-		}
+    try {
+      eventData = JSON.parse(readFileSync(GITHUB_EVENT_PATH, 'utf-8'));
+    } catch {
+      throw Error('Could not read the github event payload, nothing to do here');
+    }
 
-		return eventData;
-	};
+    return eventData;
+  };
 
-	const data = getEventData();
+  const data = getEventData();
 
-	// Then handle provided event payload (TODO to make this not strictly github based...)
-	switch (data.action) {
-		case "submitted":
-			handlePullRequestReviewSubmitted(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "closed":
-			handlePullRequestClosed(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "opened":
-			handlePullRequestOpened(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "reopened":
-			handlePullRequestReopened(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "review_requested":
-			handlePullRequestReviewRequested(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "converted_to_draft":
-			handlePullRequestConvertedToDraft(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "ready_for_review":
-			handlePullRequestReadyForReview(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		case "edited":
-			handlePullRequestEdited(repoData, data).then(() =>
-				savePullyState(repoData),
-			);
-			break;
-		default:
-			console.log(`Got unknown event to handle: ${data}`)
-	}
+  // Then handle provided event payload (TODO to make this not strictly github based...)
+  switch (data.action) {
+    case 'submitted':
+      handlePullRequestReviewSubmitted(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'closed':
+      handlePullRequestClosed(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'opened':
+      handlePullRequestOpened(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'reopened':
+      handlePullRequestReopened(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'review_requested':
+      handlePullRequestReviewRequested(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'converted_to_draft':
+      handlePullRequestConvertedToDraft(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'ready_for_review':
+      handlePullRequestReadyForReview(repoData, data).then(() => savePullyState(repoData));
+      break;
+    case 'edited':
+      handlePullRequestEdited(repoData, data).then(() => savePullyState(repoData));
+      break;
+    default:
+      console.log(`Got unknown event to handle: ${data}`);
+  }
 });
-
 
 // TODO: A better way to ship this for github would be to pack this inside a github action


### PR DESCRIPTION
Turns out that github concurrency only allows maximum two jobs to be active/pending for a concurrency group, while cancelling all others. This broke a fundamental assumption in the current state implementation, as we now lose state updates.

The fix is to rely more on github apis for current review states, and only stash information that is not easily found: the slack message timestamp. And to store this in one file per PR so that we have no write races inbetween PRs.

The rework is possible since this is now a self-hosted solution anyway. In the initial impl, we assumed no access to the original repo, while now we do.

This simplifies the state quite dramatically, and allows us to now only store this info in the state branch, further reducing state drift between what actually is on github and what the state thinks the state is on github:
- First names, slack IDs, and Github login name
- Github repo name + PR number + slack message timestamp

Also, we now only push updates to the state branch once per PR (to write the initial message timestamp). So overall activity there should also be lower now, which is nice.