### PR TITLE
Move pully config to main branch in dedicated folder

### DIFF
--- a/.pully/config.json
+++ b/.pully/config.json
@@ -1,0 +1,16 @@
+{
+  "known_authors": [
+    {
+      "githubUsername": "kristoffer-monsen-bulder",
+      "slackMemberId": "U08FWFQPT60",
+      "firstName": "Kris",
+      "slackmoji": ":meepmeep:"
+    },
+    {
+      "githubUsername": "N35N0M",
+      "slackMemberId": "U08FWFQPT60",
+      "firstName": "Kris",
+      "slackmoji": ":meepmeep:"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -27,19 +27,21 @@ It's important that any branch protection rules allows GITHUB_TOKEN to write to 
     - The message timestamp of the original slack message per pr (not considered sensitive. You cant do anything with this timestamp without read/write permission to the slack channel, and you need to know the slack channel)
     - Any provided github usernames
     - (Optional): The first name and the slack ID of github authors. **This will only be part of the state if committed to the state in step 5**
-5. (Optional, omitting this will lead to github usernames being posted) Commit the initial `pullystate.json` to the `pully-persistent-state-do-not-use-for-coding`, where you specify optional information about the authors. If you do not wish to share this information, the only effect is that the slack message wont @-mention requested reviewers, and we will use github usernames instead of first names when reporting approvals and change requests. 
+5. (Optional, omitting this will lead to github usernames being posted) Commit the initial `.pully/config.json` to your default branch (main), where you specify optional information about the authors. If you do not wish to share this information, the only effect is that the slack message wont @-mention requested reviewers, and we will use github usernames instead of first names when reporting approvals and change requests. 
 ```
 {
   "known_authors": [
     {
       "githubUsername": "kristoffer-monsen-bulder",
       "slackMemberId": "U08FWFQPT60",
-      "firstName": "Kris"
+      "firstName": "Kris",
+      "slackmoji": ":meepmeep:"
     },
     {
       "githubUsername": "N35N0M",
       "slackMemberId": "U08FWFQPT60",
-      "firstName": "Kris"
+      "firstName": "Kris",
+      "slackmoji": ":meepmeep:"
     }
   ]
 }


### PR DESCRIPTION
In our team we already use slackmojis by hacking it into the first name, which makes the postings more fun with :verynice: and :meepmeep: etc. With a dedicated field it is easier to custom format stuff in the future.

We also move the config of this to the main branch instead of the automatically kept state branch for two reasons:
1. More accessible for users
2. Less risk of conflicting with automated updates from pully

Finally, why a file and not github ci inputs: they have too limited types at the time of writing (bool, string, choice), and no more advanced structures. So a platform-independent format seemed like a better choice.