### PR TITLE
fix(core): Fix issue with mergeconflicts, address possible issue

### DIFF
--- a/.github/workflows/pully.yml
+++ b/.github/workflows/pully.yml
@@ -1,6 +1,6 @@
 # Dogfooding
 on:
-  pull_request:
+  pull_request_target:
     types: [
       opened,
       reopened,


### PR DESCRIPTION
In the context of the pully client action yaml, it seems like pull_request_target is the safer option rather than pull_request. Even though pull_request_target is widely warned against.

The reason why it is warned against, is due to the pitfall of the GITHUB_TOKEN with write-scope being present here, together with checking out PR code (potential attacker surface). Since we dont actually check out the code in order for pully to work, this should be safe, and actually safeR than today - where PR code gets a write token through context:write